### PR TITLE
Import RAD2DEG from THREE.MathUtils

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ AFRAME.registerComponent('cursor-teleport', {
 
     teleporter.isValidNormalsAngle = function (collisionNormal) {
       var angleNormals = teleporter.referenceNormal.angleTo(collisionNormal);
-      return (THREE.Math.RAD2DEG * angleNormals <= this.data.landingMaxAngle);
+      return (THREE.MathUtils.RAD2DEG * angleNormals <= this.data.landingMaxAngle);
     }
 
     teleporter.transition = function (destPos) {


### PR DESCRIPTION
Import RAD2DEG from THREE.MathUtils to be compatible with aframe 1.4.0.
This still works with aframe 1.2.0 and 1.3.0.