### PR TITLE
Set cameraRig end position when transition is finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,6 +238,7 @@ AFRAME.registerComponent('cursor-teleport', {
       teleporter.camPos.z = teleporter.transitionCamPosStart.z + ((teleporter.transitionCamPosEnd.z - teleporter.transitionCamPosStart.z) * teleporter.easeInOutQuad(teleporter.transitionProgress));
 
       if (teleporter.transitionProgress >= 1) {
+        teleporter.camPos.copy(teleporter.transitionCamPosEnd);
         teleporter.transitioning = false;
       }
     }


### PR DESCRIPTION
I had a weird behavior while testing, if I clicked on the ground then switched browser tab and came back to the tab after 2s, the cameraRig position was wrong. Copying the end position when transitionProgress >= 1 fixed it.