### PR TITLE
Remove global teleporter variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,14 +84,17 @@ AFRAME.registerComponent('cursor-teleport', {
           });
         });
       } else {
-        // if no collision entities are specified, create a default ground plane collision.
-        var geo = new THREE.PlaneGeometry(50, 50, 1);
-        geo.rotateX(-Math.PI / 2);
-        var mat = new THREE.MeshNormalMaterial();
-        var collisionMesh = new THREE.Mesh(geo, mat);
-        // mark this mesh as a collision object
-        collisionMesh.userData.collision = true;
-        teleporter.rayCastObjects.push(collisionMesh);
+        if (!teleporter.collisionMesh) {
+          // if no collision entities are specified, create a default ground plane collision.
+          var geo = new THREE.PlaneGeometry(50, 50, 1);
+          geo.rotateX(-Math.PI / 2);
+          var mat = new THREE.MeshNormalMaterial();
+          var collisionMesh = new THREE.Mesh(geo, mat);
+          // mark this mesh as a collision object
+          collisionMesh.userData.collision = true;
+          teleporter.collisionMesh = collisionMesh;
+        }
+        teleporter.rayCastObjects.push(teleporter.collisionMesh);
       }
 
       // We may need some entities to be seen by the raycaster even though they are not teleportable.

--- a/index.js
+++ b/index.js
@@ -241,6 +241,7 @@ AFRAME.registerComponent('cursor-teleport', {
       teleporter.camPos.z = teleporter.transitionCamPosStart.z + ((teleporter.transitionCamPosEnd.z - teleporter.transitionCamPosStart.z) * teleporter.easeInOutQuad(teleporter.transitionProgress));
 
       if (teleporter.transitionProgress >= 1) {
+        teleporter.camPos.copy(teleporter.transitionCamPosEnd);
         teleporter.transitioning = false;
       }
     }

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ AFRAME.registerComponent('cursor-teleport', {
 
     teleporter.isValidNormalsAngle = function (collisionNormal) {
       var angleNormals = teleporter.referenceNormal.angleTo(collisionNormal);
-      return (THREE.Math.RAD2DEG * angleNormals <= this.data.landingMaxAngle);
+      return (THREE.MathUtils.RAD2DEG * angleNormals <= this.data.landingMaxAngle);
     }
 
     teleporter.transition = function (destPos) {

--- a/index.js
+++ b/index.js
@@ -13,8 +13,9 @@ AFRAME.registerComponent('cursor-teleport', {
     cameraRig: { type: 'string', default: '' },
     collisionEntities: { type: 'string', default: '' },
     ignoreEntities: { type: 'string', default: '' },
-    landingMaxAngle: { default: '45', min: 0, max: 360 },
-    landingNormal: { type: 'vec3', default: '0 1 0' }
+    landingMaxAngle: { default: 45, min: 0, max: 360 },
+    landingNormal: { type: 'vec3', default: '0 1 0' },
+    transitionSpeed: { type: 'number', default: 0.0006 }
   },
   init: function () {
 
@@ -59,7 +60,6 @@ AFRAME.registerComponent('cursor-teleport', {
     // transition
     teleporter.transitioning = false;
     teleporter.transitionProgress = 0;
-    teleporter.transitionSpeed = .01;
     teleporter.transitionCamPosStart = new THREE.Vector3();
     teleporter.transitionCamPosEnd = new THREE.Vector3();
 
@@ -220,7 +220,7 @@ AFRAME.registerComponent('cursor-teleport', {
       return t < .5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
     }
   },
-  tick: function () {
+  tick: function (time, delta) {
     if (!teleporter.transitioning && !teleporter.mobile) {
       var pos = teleporter.getTeleportPosition(teleporter.mouseX, teleporter.mouseY);
       if (!teleporter.mobile && pos) {
@@ -230,7 +230,7 @@ AFRAME.registerComponent('cursor-teleport', {
       }
     }
     if (teleporter.transitioning) {
-      teleporter.transitionProgress += teleporter.transitionSpeed;
+      teleporter.transitionProgress += delta * teleporter.data.transitionSpeed;
 
       // set camera position
       teleporter.camPos.x = teleporter.transitionCamPosStart.x + ((teleporter.transitionCamPosEnd.x - teleporter.transitionCamPosStart.x) * teleporter.easeInOutQuad(teleporter.transitionProgress));


### PR DESCRIPTION
This contains all PRs:
- #36
- #37
- #38 
- #39

Plus:
- Remove global teleporter variable and use proper aframe component idioms, implement play pause remove, avoid object and array allocations when possible.